### PR TITLE
Add profile deletion and leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,11 @@
   <ul class="profile-list"></ul>
 
   <section>
+    <h2>Leaderboard</h2>
+    <ul id="leaderboard"></ul>
+  </section>
+
+  <section>
     <h2>Add Profile</h2>
     <form id="addKidForm">
       <input type="text" id="kidName" placeholder="Kid's Name" required>

--- a/index.js
+++ b/index.js
@@ -3,9 +3,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const kidsKey = 'kids';
   const list = document.querySelector('.profile-list');
   const form = document.getElementById('addKidForm');
-  let kids = JSON.parse(localStorage.getItem(kidsKey) || '[]');
-  if (kids.length === 0) {
-    kids = ['Kid1', 'Kid2'];
+  const leaderboard = document.getElementById('leaderboard');
+
+  const stored = localStorage.getItem(kidsKey);
+  let kids = stored ? JSON.parse(stored) : ['Kid1', 'Kid2'];
+  if (!stored) {
+    localStorage.setItem(kidsKey, JSON.stringify(kids));
   }
 
   function saveKids() {
@@ -14,17 +17,43 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function renderKids() {
     list.innerHTML = '';
-    kids.forEach(name => {
+    kids.forEach((name, idx) => {
       const li = document.createElement('li');
       const a = document.createElement('a');
       a.href = `profile.html?child=${encodeURIComponent(name)}`;
       a.textContent = `${name} Profile`;
+      const del = document.createElement('button');
+      del.textContent = 'Delete';
+      del.className = 'delete-btn';
+      del.addEventListener('click', () => {
+        if (confirm(`Delete ${name}?`)) {
+          kids.splice(idx, 1);
+          localStorage.removeItem(`${name}_videos`);
+          localStorage.removeItem(`${name}_certs`);
+          saveKids();
+          renderKids();
+          renderLeaderboard();
+        }
+      });
       li.appendChild(a);
+      li.appendChild(del);
       list.appendChild(li);
     });
   }
 
+  function renderLeaderboard() {
+    if (!leaderboard) return;
+    leaderboard.innerHTML = '';
+    kids.forEach(name => {
+      const certs = JSON.parse(localStorage.getItem(`${name}_certs`) || '[]');
+      const li = document.createElement('li');
+      li.textContent = `${name}: ${certs.length} certificates`;
+      leaderboard.appendChild(li);
+    });
+  }
+
   renderKids();
+  renderLeaderboard();
 
   form.addEventListener('submit', e => {
     e.preventDefault();
@@ -34,6 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
       kids.push(name);
       saveKids();
       renderKids();
+      renderLeaderboard();
       form.reset();
     }
   });

--- a/style.css
+++ b/style.css
@@ -78,3 +78,25 @@ video {
 .profile-list li a:hover {
   background: #45a049;
 }
+
+.delete-btn {
+  margin-left: 10px;
+  background: #f44336;
+}
+
+.delete-btn:hover {
+  background: #d32f2f;
+}
+
+#leaderboard {
+  list-style: none;
+  padding: 0;
+}
+
+#leaderboard li {
+  background: #fff;
+  padding: 8px 12px;
+  margin-bottom: 5px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}


### PR DESCRIPTION
## Summary
- allow deleting kid profiles and remove related data
- include leaderboard displaying certificates per kid
- show delete button style and scoreboard styling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6888222f05f483318bb628601e9f31bd